### PR TITLE
Use UMD as the default export format

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,16 @@ import minify from 'rollup-plugin-babel-minify';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 
+const preferredDefaultOutputFormat = {
+  format: 'umd',
+  name: 'postgrestSyntaxBuilder',
+};
+
 export default {
   input: 'src/index.js',
   output: [
     {
-      file: 'dist/index.js',
+      file: 'dist/index.esm.js',
       format: 'esm',
     },
     {
@@ -16,8 +21,11 @@ export default {
     },
     {
       file: 'dist/index.umd.js',
-      format: 'umd',
-      name: 'postgrestSyntaxBuilder',
+      ...preferredDefaultOutputFormat,
+    },
+    {
+      file: 'dist/index.js',
+      ...preferredDefaultOutputFormat,
     },
   ],
   plugins: [


### PR DESCRIPTION
Use UMD over ESM as the default export format to widen library's compatibility with more project in the wild.

Most tool (i.e. webpack, babel) does not transpile `node_modules` packages by default. On node 8 and 10, ESM support is still behind `--experimental-modules` flag.

So, let's use UMD for now.